### PR TITLE
Revert tap detection back to click event

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -87,19 +87,8 @@
         );
         updateBookmarks();
         const INTERACTIVE_TAGS = { A: 1, BUTTON: 1, INPUT: 1, SELECT: 1, TEXTAREA: 1, LABEL: 1, SUMMARY: 1 };
-        // Listen to touchend (not click) to ignore mouse input on desktop. Walk parents
-        // manually instead of Element.closest(): unavailable on old e-ink WebKit browsers.
-        var touchStartX = 0, touchStartY = 0;
-        document.addEventListener('touchstart', function(event) {
-            var t = event.changedTouches[0];
-            touchStartX = t.clientX;
-            touchStartY = t.clientY;
-        });
-        document.addEventListener('touchend', function(event) {
-            var t = event.changedTouches[0];
-            if (Math.abs(t.clientX - touchStartX) > 10 || Math.abs(t.clientY - touchStartY) > 10) {
-                return;
-            }
+        // Walk parents manually instead of Element.closest(): unavailable on old e-ink WebKit browsers.
+        document.addEventListener('click', function(event) {
             var el = event.target;
             while (el && el.nodeType === 1) {
                 if (INTERACTIVE_TAGS[el.tagName]) {
@@ -111,7 +100,7 @@
                 }
                 el = el.parentNode;
             }
-            window.scrollBy(0, t.clientX > (window.innerWidth/2) ? window.innerHeight : -window.innerHeight);
+            window.scrollBy(0, event.clientX > (window.innerWidth/2) ? window.innerHeight : -window.innerHeight);
         });
         {{if .URL}}
         const url = {{.URL}};


### PR DESCRIPTION
## Summary
- `touchend`-based detection did not fire reliably on the target e-ink device, so page-turn taps stopped working.
- Restores the `click` listener while keeping the interactive-element skip (links, form controls, labels, summaries, `role=button`, contenteditable) and the manual parent walk for old-WebKit compatibility.

## Test plan
- [ ] Tap the left/right halves of the page on an e-ink reader and confirm the page scrolls up/down.
- [ ] Tap a button, link, or form control and confirm the native action fires without triggering a scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)